### PR TITLE
OY-5116 Jacksonin päivitys

### DIFF
--- a/viestinvalityspalvelu/kirjasto/pom.xml
+++ b/viestinvalityspalvelu/kirjasto/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>jackson-module-scala_3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.thoughtworks.paranamer</groupId>
+            <artifactId>paranamer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/viestinvalityspalvelu/kirjasto/pom.xml
+++ b/viestinvalityspalvelu/kirjasto/pom.xml
@@ -40,10 +40,6 @@
             <artifactId>jackson-module-scala_3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.thoughtworks.paranamer</groupId>
-            <artifactId>paranamer</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
@@ -89,6 +85,11 @@
                                     <include>opiskelijavalinnat-utils.viestinvalitys:*</include>
                                     <include>org.scala-lang:*</include>
                                     <include>com.fasterxml.jackson.module:jackson-module-scala_3</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
+                                    <include>com.thoughtworks.paranamer:paranamer</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -100,6 +101,11 @@
                                 <relocation>
                                     <pattern>com.fasterxml.jackson.module.scala</pattern>
                                     <shadedPattern>viestinvalitys.com.fasterxml.jackson.module.scala</shadedPattern>
+                                </relocation>
+                                <!-- Lisätään muutkin Jackson-riippuvuudet, ettei palveluiden Jackson-versiot aiheuta konfliktia Scala Modulen kanssa. -->
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>viestinvalitys.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/viestinvalityspalvelu/pom.xml
+++ b/viestinvalityspalvelu/pom.xml
@@ -11,7 +11,7 @@
   </modules>
 
   <properties>
-    <revision>1.2.4-SNAPSHOT</revision>
+    <revision>1.2.5-SNAPSHOT</revision>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <encoding>UTF-8</encoding>

--- a/viestinvalityspalvelu/pom.xml
+++ b/viestinvalityspalvelu/pom.xml
@@ -253,11 +253,6 @@
       </dependency>
       <!-- Shadetetun Scala-modulen dependency dependency ei asennu kirjaston mukana ilman suoraa dependencyä. -->
       <dependency>
-        <groupId>com.thoughtworks.paranamer</groupId>
-        <artifactId>paranamer</artifactId>
-        <version>2.8.3</version>
-      </dependency>
-      <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>
         <version>2.0.1</version>

--- a/viestinvalityspalvelu/pom.xml
+++ b/viestinvalityspalvelu/pom.xml
@@ -251,6 +251,12 @@
         <artifactId>jackson-module-scala_3</artifactId>
         <version>${jackson.version}</version>
       </dependency>
+      <!-- Shadetetun Scala-modulen dependency dependency ei asennu kirjaston mukana ilman suoraa dependencyä. -->
+      <dependency>
+        <groupId>com.thoughtworks.paranamer</groupId>
+        <artifactId>paranamer</artifactId>
+        <version>2.8.3</version>
+      </dependency>
       <dependency>
         <groupId>com.sun.activation</groupId>
         <artifactId>jakarta.activation</artifactId>

--- a/viestinvalityspalvelu/pom.xml
+++ b/viestinvalityspalvelu/pom.xml
@@ -11,14 +11,14 @@
   </modules>
 
   <properties>
-    <revision>1.2.3-SNAPSHOT</revision>
+    <revision>1.2.4-SNAPSHOT</revision>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <encoding>UTF-8</encoding>
     <scala.version>3.3.3</scala.version>
     <spring.boot.version>3.3.11</spring.boot.version>
     <awssdk.version>2.21.17</awssdk.version>
-    <jackson.version>2.18.1</jackson.version>
+    <jackson.version>2.20.1</jackson.version>
     <java.cas.version>2.0.0-SNAPSHOT</java.cas.version>
   </properties>
 


### PR DESCRIPTION
Maksuissa tuli ongelmia, kun tämän kirjaston riippuvuutena oleva Jacksonin Scala-module oli vanhempi versio kuin käytössä oleva Jackson-core. Jostain syystä Scala-module ei näy riippuvuutena maksuissa, joten pelkän Scala-module versiota ei voi pakottaa uudempaan. Ratkaisuna päivitetään tämän kirjaston Jackson-versio.